### PR TITLE
Feature/redis jwt auth

### DIFF
--- a/wecare-backend/wecare/build.gradle
+++ b/wecare-backend/wecare/build.gradle
@@ -36,6 +36,11 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     testRuntimeOnly 'com.h2database:h2'
+
+    // JWT
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 }
 
 tasks.named('test') {

--- a/wecare-backend/wecare/src/main/java/com/example/wecare/auth/controller/AuthController.java
+++ b/wecare-backend/wecare/src/main/java/com/example/wecare/auth/controller/AuthController.java
@@ -1,14 +1,14 @@
 package com.example.wecare.auth.controller;
 
+import com.example.wecare.auth.dto.LoginRequest;
+import com.example.wecare.auth.dto.LoginResponse;
 import com.example.wecare.auth.dto.SignUpRequest;
+import com.example.wecare.auth.dto.TokenDto;
 import com.example.wecare.auth.service.AuthService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/auth")
@@ -26,4 +26,37 @@ public class AuthController {
             return ResponseEntity.badRequest().body(e.getMessage());
         }
     }
+
+    @PostMapping("/login")
+    public ResponseEntity<LoginResponse> login(@Valid @RequestBody LoginRequest loginRequest) {
+        TokenDto tokenDto = authService.login(loginRequest);
+        return ResponseEntity.ok(LoginResponse.builder()
+                .accessToken(tokenDto.getAccessToken())
+                .refreshToken(tokenDto.getRefreshToken())
+                .build());
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<String> logout(@RequestHeader("Authorization") String accessToken) {
+        // "Bearer " 접두사 제거
+        if (accessToken != null && accessToken.startsWith("Bearer ")) {
+            accessToken = accessToken.substring(7);
+        }
+        authService.logout(accessToken);
+        return ResponseEntity.ok("로그아웃 되었습니다.");
+    }
+
+    @PostMapping("/reissue")
+    public ResponseEntity<LoginResponse> reissue(@RequestHeader("Authorization") String refreshToken) {
+        // "Bearer " 접두사 제거
+        if (refreshToken != null && refreshToken.startsWith("Bearer ")) {
+            refreshToken = refreshToken.substring(7);
+        }
+        TokenDto tokenDto = authService.reissue(refreshToken);
+        return ResponseEntity.ok(LoginResponse.builder()
+                .accessToken(tokenDto.getAccessToken())
+                .refreshToken(tokenDto.getRefreshToken())
+                .build());
+    }
 }
+

--- a/wecare-backend/wecare/src/main/java/com/example/wecare/auth/dto/LoginRequest.java
+++ b/wecare-backend/wecare/src/main/java/com/example/wecare/auth/dto/LoginRequest.java
@@ -1,0 +1,11 @@
+package com.example.wecare.auth.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class LoginRequest {
+    private String phone;
+    private String password;
+}

--- a/wecare-backend/wecare/src/main/java/com/example/wecare/auth/dto/LoginResponse.java
+++ b/wecare-backend/wecare/src/main/java/com/example/wecare/auth/dto/LoginResponse.java
@@ -1,0 +1,15 @@
+package com.example.wecare.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class LoginResponse {
+    private String accessToken;
+    private String refreshToken;
+}

--- a/wecare-backend/wecare/src/main/java/com/example/wecare/auth/dto/SignUpRequest.java
+++ b/wecare-backend/wecare/src/main/java/com/example/wecare/auth/dto/SignUpRequest.java
@@ -16,6 +16,7 @@ import java.time.LocalDate;
 public class SignUpRequest {
 
     @NotBlank(message = "비밀번호는 필수 입력 값입니다.")
+    @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d).{8,}$", message = "비밀번호는 8자리 이상이어야 하며, 영어와 숫자를 포함해야 합니다.")
     private String password;
 
     @NotBlank(message = "이름은 필수 입력 값입니다.")

--- a/wecare-backend/wecare/src/main/java/com/example/wecare/auth/dto/TokenDto.java
+++ b/wecare-backend/wecare/src/main/java/com/example/wecare/auth/dto/TokenDto.java
@@ -1,0 +1,15 @@
+package com.example.wecare.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class TokenDto {
+    private String accessToken;
+    private String refreshToken;
+}

--- a/wecare-backend/wecare/src/main/java/com/example/wecare/auth/jwt/JwtAuthenticationFilter.java
+++ b/wecare-backend/wecare/src/main/java/com/example/wecare/auth/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,44 @@
+package com.example.wecare.auth.jwt;
+
+import jakarta.servlet.ServletException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.GenericFilterBean;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import java.io.IOException;
+
+public class JwtAuthenticationFilter extends GenericFilterBean {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    public JwtAuthenticationFilter(JwtTokenProvider jwtTokenProvider) {
+        this.jwtTokenProvider = jwtTokenProvider;
+    }
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+        HttpServletRequest httpServletRequest = (HttpServletRequest) request;
+        String jwt = resolveToken(httpServletRequest);
+
+        if (StringUtils.hasText(jwt) && jwtTokenProvider.validateToken(jwt)) {
+            Authentication authentication = jwtTokenProvider.getAuthentication(jwt);
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+
+        chain.doFilter(request, response);
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7);
+        }
+        return null;
+    }
+}

--- a/wecare-backend/wecare/src/main/java/com/example/wecare/auth/jwt/JwtAuthenticationFilter.java
+++ b/wecare-backend/wecare/src/main/java/com/example/wecare/auth/jwt/JwtAuthenticationFilter.java
@@ -7,7 +7,6 @@ import org.springframework.util.StringUtils;
 import org.springframework.web.filter.GenericFilterBean;
 
 import jakarta.servlet.FilterChain;
-import jakarta.servlet.ServletException;
 import jakarta.servlet.ServletRequest;
 import jakarta.servlet.ServletResponse;
 import jakarta.servlet.http.HttpServletRequest;

--- a/wecare-backend/wecare/src/main/java/com/example/wecare/auth/jwt/JwtTokenProvider.java
+++ b/wecare-backend/wecare/src/main/java/com/example/wecare/auth/jwt/JwtTokenProvider.java
@@ -1,0 +1,119 @@
+package com.example.wecare.auth.jwt;
+
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+
+import jakarta.annotation.PostConstruct;
+import java.security.Key;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Date;
+import java.util.stream.Collectors;
+
+@Component
+public class JwtTokenProvider {
+
+    @Value("${jwt.secret}")
+    private String secret;
+
+    @Value("${jwt.access-token-expiration-time}")
+    private long accessTokenExpirationTime;
+
+    @Value("${jwt.refresh-token-expiration-time}")
+    private long refreshTokenExpirationTime;
+
+    private Key key;
+
+    @PostConstruct
+    public void init() {
+        this.key = Keys.hmacShaKeyFor(secret.getBytes());
+    }
+
+    // JWT 토큰 생성
+    public String createToken(Authentication authentication, long expirationTime) {
+        String authorities = authentication.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .collect(Collectors.joining(","));
+
+        Date now = new Date();
+        Date validity = new Date(now.getTime() + expirationTime);
+
+        return Jwts.builder()
+                .setSubject(authentication.getName())
+                .claim("auth", authorities)
+                .setIssuedAt(now)
+                .setExpiration(validity)
+                .signWith(key, SignatureAlgorithm.HS512)
+                .compact();
+    }
+
+    // Access Token 생성
+    public String createAccessToken(Authentication authentication) {
+        return createToken(authentication, accessTokenExpirationTime);
+    }
+
+    // Refresh Token 생성
+    public String createRefreshToken(Authentication authentication) {
+        return createToken(authentication, refreshTokenExpirationTime);
+    }
+
+    // JWT 토큰에서 인증 정보 조회
+    public Authentication getAuthentication(String token) {
+        Claims claims = Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+
+        Collection<? extends GrantedAuthority> authorities =
+                Arrays.stream(claims.get("auth").toString().split(","))
+                        .map(SimpleGrantedAuthority::new)
+                        .collect(Collectors.toList());
+
+        UserDetails principal = new User(claims.getSubject(), "", authorities);
+
+        return new UsernamePasswordAuthenticationToken(principal, token, authorities);
+    }
+
+    // 토큰의 유효성 + 만료일자 확인
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+            return true;
+        } catch (io.jsonwebtoken.security.SecurityException | MalformedJwtException e) {
+            // logger.info("잘못된 JWT 서명입니다.");
+        } catch (ExpiredJwtException e) {
+            // logger.info("만료된 JWT 토큰입니다.");
+        } catch (UnsupportedJwtException e) {
+            // logger.info("지원되지 않는 JWT 토큰입니다.");
+        } catch (IllegalArgumentException e) {
+            // logger.info("JWT 토큰이 잘못되었습니다.");
+        }
+        return false;
+    }
+
+    // 토큰에서 사용자 ID 추출
+    public String getUserIdFromToken(String token) {
+        return Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token).getBody().getSubject();
+    }
+
+    // Refresh Token 만료 시간 조회
+    public long getRefreshTokenExpirationTime() {
+        return refreshTokenExpirationTime;
+    }
+
+    // 토큰의 만료 시간 조회
+    public Long getExpiration(String token) {
+        Date expiration = Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token).getBody().getExpiration();
+        Long now = new Date().getTime();
+        return expiration.getTime() - now;
+    }
+}

--- a/wecare-backend/wecare/src/main/java/com/example/wecare/auth/service/AuthService.java
+++ b/wecare-backend/wecare/src/main/java/com/example/wecare/auth/service/AuthService.java
@@ -1,19 +1,33 @@
 package com.example.wecare.auth.service;
 
-import com.example.wecare.member.domain.Member;
+import com.example.wecare.auth.dto.LoginRequest;
 import com.example.wecare.auth.dto.SignUpRequest;
+import com.example.wecare.auth.dto.TokenDto;
+import com.example.wecare.auth.jwt.JwtTokenProvider;
+import com.example.wecare.member.domain.Member;
 import com.example.wecare.member.repository.MemberRepository;
+import com.example.wecare.redis.service.RedisService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.concurrent.TimeUnit;
+
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class AuthService {
 
     private final MemberRepository memberRepository;
     private final PasswordEncoder passwordEncoder;
+    private final AuthenticationManagerBuilder authenticationManagerBuilder;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final RedisService redisService;
 
     @Transactional
     public void signUp(SignUpRequest request) {
@@ -25,10 +39,89 @@ public class AuthService {
         member.setPassword(passwordEncoder.encode(request.getPassword()));
         member.setName(request.getName());
         member.setGender(request.getGender());
-        member.setBirthDate(request.getBirthDate().atStartOfDay());
+        member.setBirthDate(request.getBirthDate());
         member.setPhone(request.getPhone());
         member.setRole(request.getRole());
 
         memberRepository.save(member);
     }
+
+    @Transactional
+    public TokenDto login(LoginRequest loginRequest) {
+        log.info("Attempting login for phone: {}", loginRequest.getPhone());
+        // 1. Login ID/PW 를 기반으로 Authentication 객체 생성
+        // 이때 authentication 는 인증 여부를 확인하는 authenticated 값이 false
+        UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(loginRequest.getPhone(), loginRequest.getPassword());
+
+        // 2. 실제 검증 (사용자 비밀번호 체크)이 이루어지는 부분
+        // authenticate 매서드가 실행될 때 CustomUserDetailsService 에서 만든 loadUserByUsername 메서드가 실행
+        Authentication authentication = null;
+        try {
+            authentication = authenticationManagerBuilder.getObject().authenticate(authenticationToken);
+            log.info("Authentication successful for phone: {}", loginRequest.getPhone());
+        } catch (Exception e) {
+            log.error("Authentication failed for phone: {}. Error: {}", loginRequest.getPhone(), e.getMessage());
+            throw e; // 예외를 다시 던져서 컨트롤러에서 처리하도록 함
+        }
+
+        // 3. 인증 정보를 기반으로 JWT 토큰 생성
+        TokenDto tokenDto = TokenDto.builder()
+                .accessToken(jwtTokenProvider.createAccessToken(authentication))
+                .refreshToken(jwtTokenProvider.createRefreshToken(authentication))
+                .build();
+
+        // 4. RefreshToken Redis 저장 (expirationTime 설정을 통해 자동 삭제 처리)
+        redisService.setValues(authentication.getName(), tokenDto.getRefreshToken(), jwtTokenProvider.getRefreshTokenExpirationTime(), TimeUnit.MILLISECONDS);
+
+        return tokenDto;
+    }
+
+    @Transactional
+    public void logout(String accessToken) {
+        // 1. Access Token 검증
+        if (!jwtTokenProvider.validateToken(accessToken)) {
+            throw new IllegalArgumentException("유효하지 않은 Access Token 입니다.");
+        }
+
+        // 2. Access Token 에서 Authentication 추출
+        Authentication authentication = jwtTokenProvider.getAuthentication(accessToken);
+
+        // 3. Redis 에서 해당 User ID 로 저장된 Refresh Token 이 있는지 여부 확인 후 있을 경우 삭제
+        if (redisService.getValues(authentication.getName()) != null) {
+            redisService.deleteValues(authentication.getName());
+        }
+
+        // 4. 해당 Access Token 유효시간 가지고 와서 BlackList 로 저장
+        Long expiration = jwtTokenProvider.getExpiration(accessToken);
+        redisService.setValues(accessToken, "logout", expiration, TimeUnit.MILLISECONDS);
+    }
+
+    @Transactional
+    public TokenDto reissue(String refreshToken) {
+        // 1. Refresh Token 검증
+        if (!jwtTokenProvider.validateToken(refreshToken)) {
+            throw new IllegalArgumentException("유효하지 않은 Refresh Token 입니다.");
+        }
+
+        // 2. Refresh Token 에서 Authentication 추출
+        Authentication authentication = jwtTokenProvider.getAuthentication(refreshToken);
+
+        // 3. Redis 에서 User ID 기반으로 저장된 Refresh Token 값 조회
+        String redisRefreshToken = redisService.getValues(authentication.getName());
+        if (redisRefreshToken == null || !redisRefreshToken.equals(refreshToken)) {
+            throw new IllegalArgumentException("Refresh Token 정보가 일치하지 않습니다.");
+        }
+
+        // 4. 새로운 토큰 생성
+        TokenDto tokenDto = TokenDto.builder()
+                .accessToken(jwtTokenProvider.createAccessToken(authentication))
+                .refreshToken(jwtTokenProvider.createRefreshToken(authentication))
+                .build();
+
+        // 5. RefreshToken Redis 업데이트
+        redisService.setValues(authentication.getName(), tokenDto.getRefreshToken(), jwtTokenProvider.getRefreshTokenExpirationTime(), TimeUnit.MILLISECONDS);
+
+        return tokenDto;
+    }
 }
+

--- a/wecare-backend/wecare/src/main/java/com/example/wecare/auth/service/CustomUserDetailsService.java
+++ b/wecare-backend/wecare/src/main/java/com/example/wecare/auth/service/CustomUserDetailsService.java
@@ -1,0 +1,41 @@
+package com.example.wecare.auth.service;
+
+import com.example.wecare.member.domain.Member;
+import com.example.wecare.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collections;
+
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final MemberRepository memberRepository;
+
+    @Override
+    @Transactional
+    public UserDetails loadUserByUsername(String phone) throws UsernameNotFoundException {
+        return memberRepository.findByPhone(phone)
+                .map(this::createUserDetails)
+                .orElseThrow(() -> new UsernameNotFoundException(phone + " -> 데이터베이스에서 찾을 수 없습니다."));
+    }
+
+    // DB 에 User 값이 존재한다면 UserDetails 객체로 만들어서 리턴
+    private UserDetails createUserDetails(Member member) {
+        GrantedAuthority grantedAuthority = new SimpleGrantedAuthority(member.getRole().toString());
+
+        return new User(
+                String.valueOf(member.getPhone()),
+                member.getPassword(),
+                Collections.singleton(grantedAuthority)
+        );
+    }
+}

--- a/wecare-backend/wecare/src/main/java/com/example/wecare/config/CorsConfig.java
+++ b/wecare-backend/wecare/src/main/java/com/example/wecare/config/CorsConfig.java
@@ -12,7 +12,7 @@ public class CorsConfig {
     @Bean
     public CorsFilter corsFilter() {
         CorsConfiguration config = new CorsConfiguration();
-        config.setAllowedOrigins(List.of("http://localhost:63342", "http://localhost:8080"));
+        config.setAllowedOrigins(List.of("http://localhost:63342", "http://localhost:8080", "http://localhost:3000"));
         config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH"));
         config.setAllowedHeaders(List.of("*"));
         config.setAllowCredentials(true);

--- a/wecare-backend/wecare/src/main/java/com/example/wecare/config/SecurityConfig.java
+++ b/wecare-backend/wecare/src/main/java/com/example/wecare/config/SecurityConfig.java
@@ -1,16 +1,33 @@
 package com.example.wecare.config;
 
+import com.example.wecare.auth.jwt.JwtAuthenticationFilter;
+import com.example.wecare.auth.jwt.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.List;
 
 @Configuration
 @EnableWebSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final AuthenticationManagerBuilder authenticationManagerBuilder;
 
     @Bean
     public PasswordEncoder passwordEncoder() {
@@ -18,14 +35,34 @@ public class SecurityConfig {
     }
 
     @Bean
+    public AuthenticationManager authenticationManager() throws Exception {
+        return authenticationManagerBuilder.getObject();
+    }
+
+    @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
+                .cors(Customizer.withDefaults()) // CORS 설정 적용
                 .csrf(csrf -> csrf.disable())
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)) // JWT 사용으로 세션 비활성화
                 .authorizeHttpRequests(authorize -> authorize
-                        .requestMatchers("/auth/**").permitAll()
-                        //.anyRequest().authenticated()
-                        .anyRequest().permitAll() // 모든 요청 허용
-                );
+                        .requestMatchers("/auth/**", "/error").permitAll() // 인증 관련 및 기본 에러 경로 허용
+                        .anyRequest().authenticated() // 그 외 모든 요청은 인증 필요
+                )
+                .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class); // JWT 필터 추가
         return http.build();
     }
+
+    @Bean
+    CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.setAllowedOrigins(List.of("http://localhost:3000"));
+        configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+        configuration.setAllowedHeaders(List.of("*"));
+        configuration.setAllowCredentials(true);
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
+    }
 }
+

--- a/wecare-backend/wecare/src/main/java/com/example/wecare/config/SecurityConfig.java
+++ b/wecare-backend/wecare/src/main/java/com/example/wecare/config/SecurityConfig.java
@@ -47,7 +47,8 @@ public class SecurityConfig {
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)) // JWT 사용으로 세션 비활성화
                 .authorizeHttpRequests(authorize -> authorize
                         .requestMatchers("/auth/**", "/error").permitAll() // 인증 관련 및 기본 에러 경로 허용
-                        .anyRequest().authenticated() // 그 외 모든 요청은 인증 필요
+                        //.anyRequest().authenticated() // 그 외 모든 요청은 인증 필요
+                        .anyRequest().permitAll()
                 )
                 .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class); // JWT 필터 추가
         return http.build();

--- a/wecare-backend/wecare/src/main/java/com/example/wecare/member/domain/Member.java
+++ b/wecare-backend/wecare/src/main/java/com/example/wecare/member/domain/Member.java
@@ -6,6 +6,7 @@ import lombok.Setter;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Getter
@@ -29,7 +30,7 @@ public class Member {
     private Gender gender;
 
     @Column(nullable = false)
-    private LocalDateTime birthDate;
+    private LocalDate birthDate;
 
     @Column(nullable = false, unique = true, length = 20)
     private String phone;

--- a/wecare-backend/wecare/src/main/java/com/example/wecare/redis/controller/RedisController.java
+++ b/wecare-backend/wecare/src/main/java/com/example/wecare/redis/controller/RedisController.java
@@ -1,0 +1,41 @@
+package com.example.wecare.redis.controller;
+
+import com.example.wecare.redis.service.RedisService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.concurrent.TimeUnit;
+
+@RestController
+@RequestMapping("/redis")
+@RequiredArgsConstructor
+public class RedisController {
+
+    private final RedisService redisService;
+
+    @PostMapping("/set")
+    public ResponseEntity<String> setKey(
+            @RequestParam String key,
+            @RequestParam String value,
+            @RequestParam(defaultValue = "60") long ttlSeconds) {
+                redisService.setValues(key, value, ttlSeconds, TimeUnit.MILLISECONDS);
+        return ResponseEntity.ok("저장 완료");
+    }
+
+    @GetMapping("/get")
+    public ResponseEntity<String> getKey( @RequestParam String key) {
+        String value = redisService.getValues(key);
+        if (value == null) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body("존재하지 않음");
+        }
+        return ResponseEntity.ok(value);
+    }
+
+    @DeleteMapping("/delete")
+    public ResponseEntity<String> deleteKey( @RequestParam String key) {
+        redisService.deleteValues(key);
+        return ResponseEntity.ok("삭제 완료");
+    }
+}

--- a/wecare-backend/wecare/src/main/java/com/example/wecare/redis/service/RedisService.java
+++ b/wecare-backend/wecare/src/main/java/com/example/wecare/redis/service/RedisService.java
@@ -1,0 +1,9 @@
+package com.example.wecare.redis.service;
+
+import java.util.concurrent.TimeUnit;
+
+public interface RedisService {
+    void setValues(String key, String value, long timeout, TimeUnit unit);
+    String getValues(String key);
+    void deleteValues(String key);
+}

--- a/wecare-backend/wecare/src/main/java/com/example/wecare/redis/service/RedisServiceImpl.java
+++ b/wecare-backend/wecare/src/main/java/com/example/wecare/redis/service/RedisServiceImpl.java
@@ -1,0 +1,30 @@
+package com.example.wecare.redis.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.concurrent.TimeUnit;
+
+@Service
+@RequiredArgsConstructor
+public class RedisServiceImpl implements RedisService {
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    @Override
+    public void setValues(String key, String value, long timeout, TimeUnit unit) {
+        redisTemplate.opsForValue().set(key, value, timeout, unit);
+    }
+
+    @Override
+    public String getValues(String key) {
+        return redisTemplate.opsForValue().get(key);
+    }
+
+    @Override
+    public void deleteValues(String key) {
+        redisTemplate.delete(key);
+    }
+
+}

--- a/wecare-backend/wecare/src/test/java/com/example/wecare/auth/controller/AuthControllerTest.java
+++ b/wecare-backend/wecare/src/test/java/com/example/wecare/auth/controller/AuthControllerTest.java
@@ -47,6 +47,23 @@ class AuthControllerTest {
     }
 
     @Test
+    @DisplayName("특수문자를 포함한 유효한 비밀번호로 회원가입을 요청하면 성공(200 OK)해야 한다.")
+    void signUp_Success_WithSpecialCharacters() throws Exception {
+        SignUpRequest request = new SignUpRequest();
+        request.setPassword("password123!"); // 특수문자 포함
+        request.setName("테스트2");
+        request.setGender(Gender.FEMALE);
+        request.setBirthDate(LocalDate.of(1995, 5, 10));
+        request.setPhone("010-9876-5432");
+        request.setRole(Role.DEPENDENT);
+
+        mockMvc.perform(post("/auth/signup")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk());
+    }
+
+    @Test
     @DisplayName("잘못된 전화번호 형식으로 회원가입을 요청하면 실패(400 Bad Request)해야 한다.")
     void signUp_Fail_InvalidPhoneNumber() throws Exception {
         SignUpRequest request = new SignUpRequest();
@@ -69,6 +86,57 @@ class AuthControllerTest {
         SignUpRequest request = new SignUpRequest();
         request.setPassword("password123");
         // request.setName("테스트"); // Missing name
+        request.setGender(Gender.MALE);
+        request.setBirthDate(LocalDate.of(1990, 1, 1));
+        request.setPhone("010-1234-5678");
+        request.setRole(Role.GUARDIAN);
+
+        mockMvc.perform(post("/auth/signup")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("비밀번호가 8자리 미만이면 회원가입이 실패(400 Bad Request)해야 한다.")
+    void signUp_Fail_InvalidPassword_TooShort() throws Exception {
+        SignUpRequest request = new SignUpRequest();
+        request.setPassword("pass123"); // 7자리
+        request.setName("테스트");
+        request.setGender(Gender.MALE);
+        request.setBirthDate(LocalDate.of(1990, 1, 1));
+        request.setPhone("010-1234-5678");
+        request.setRole(Role.GUARDIAN);
+
+        mockMvc.perform(post("/auth/signup")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("비밀번호에 영문자가 없으면 회원가입이 실패(400 Bad Request)해야 한다.")
+    void signUp_Fail_InvalidPassword_NoLetter() throws Exception {
+        SignUpRequest request = new SignUpRequest();
+        request.setPassword("12345678"); // 영문자 없음
+        request.setName("테스트");
+        request.setGender(Gender.MALE);
+        request.setBirthDate(LocalDate.of(1990, 1, 1));
+        request.setPhone("010-1234-5678");
+        request.setRole(Role.GUARDIAN);
+
+        mockMvc.perform(post("/auth/signup")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("비밀번호에 숫자가 없으면 회원가입이 실패(400 Bad Request)해야 한다.")
+    void signUp_Fail_InvalidPassword_NoDigit() throws Exception {
+        SignUpRequest request = new SignUpRequest();
+        request.setPassword("password"); // 숫자 없음
+        request.setName("테스트");
         request.setGender(Gender.MALE);
         request.setBirthDate(LocalDate.of(1990, 1, 1));
         request.setPhone("010-1234-5678");

--- a/wecare-backend/wecare/src/test/java/com/example/wecare/auth/jwt/JwtSecretKeyGenerator.java
+++ b/wecare-backend/wecare/src/test/java/com/example/wecare/auth/jwt/JwtSecretKeyGenerator.java
@@ -1,0 +1,23 @@
+package com.example.wecare.auth.jwt;
+
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+
+import javax.crypto.SecretKey;
+import java.util.Base64;
+
+public class JwtSecretKeyGenerator {
+
+    /**
+     * HS256 알고리즘 기준으로 SecretKey를 Base64 문자열로 반환
+     */
+    public static String generateBase64SecretKey() {
+        SecretKey key = Keys.secretKeyFor(SignatureAlgorithm.HS512); // or HS256
+        return Base64.getEncoder().encodeToString(key.getEncoded());
+    }
+
+    public static void main(String[] args) {
+        String secret = generateBase64SecretKey();
+        System.out.println("Generated Secret Key (Base64):\n" + secret);
+    }
+}

--- a/wecare-backend/wecare/src/test/java/com/example/wecare/auth/jwt/JwtTokenProviderTest.java
+++ b/wecare-backend/wecare/src/test/java/com/example/wecare/auth/jwt/JwtTokenProviderTest.java
@@ -1,0 +1,140 @@
+
+package com.example.wecare.auth.jwt;
+
+import com.example.wecare.member.domain.Role;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SpringBootTest
+class JwtTokenProviderTest {
+
+    @Autowired
+    private JwtTokenProvider jwtTokenProvider;
+
+    private Authentication authentication;
+
+    @BeforeEach
+    void setUp() {
+        authentication = new UsernamePasswordAuthenticationToken(
+                "testUser",
+                null,
+                Collections.singleton(new SimpleGrantedAuthority(Role.GUARDIAN.name()))
+        );
+    }
+
+    @Test
+    @DisplayName("엑세스 토큰과 리프레시 토큰이 정상적으로 생성되어야 한다.")
+    void createToken_Success() {
+        // when
+        String accessToken = jwtTokenProvider.createAccessToken(authentication);
+        String refreshToken = jwtTokenProvider.createRefreshToken(authentication);
+
+        // then
+        assertThat(accessToken).isNotNull();
+        assertThat(refreshToken).isNotNull();
+
+        Authentication authFromAccessToken = jwtTokenProvider.getAuthentication(accessToken);
+        assertThat(authFromAccessToken.getName()).isEqualTo("testUser");
+        assertThat(authFromAccessToken.getAuthorities().stream().map(GrantedAuthority::getAuthority)).containsExactly(Role.GUARDIAN.name());
+
+        Authentication authFromRefreshToken = jwtTokenProvider.getAuthentication(refreshToken);
+        assertThat(authFromRefreshToken.getName()).isEqualTo("testUser");
+    }
+
+    @Test
+    @DisplayName("유효한 토큰은 검증을 통과해야 한다.")
+    void validateToken_Success() {
+        // given
+        String token = jwtTokenProvider.createAccessToken(authentication);
+
+        // when
+        boolean isValid = jwtTokenProvider.validateToken(token);
+
+        // then
+        assertTrue(isValid);
+    }
+
+    @Test
+    @DisplayName("만료된 토큰은 검증에 실패해야 한다.")
+    void validateToken_Fail_Expired() throws InterruptedException {
+        // given
+        ReflectionTestUtils.setField(jwtTokenProvider, "accessTokenExpirationTime", 0L);
+        String expiredToken = jwtTokenProvider.createAccessToken(authentication);
+
+        // when
+        Thread.sleep(10); // Ensure the token is expired
+        boolean isValid = jwtTokenProvider.validateToken(expiredToken);
+
+        // then
+        assertFalse(isValid);
+
+        ReflectionTestUtils.setField(jwtTokenProvider, "accessTokenExpirationTime", 86400000L); // Restore original value
+    }
+
+    @Test
+    @DisplayName("손상된 토큰은 검증에 실패해야 한다.")
+    void validateToken_Fail_Invalid() {
+        // given
+        String invalidToken = "invalid.token.string";
+
+        // when
+        boolean isValid = jwtTokenProvider.validateToken(invalidToken);
+
+        // then
+        assertFalse(isValid);
+    }
+
+    @Test
+    @DisplayName("토큰에서 인증 정보를 정상적으로 추출해야 한다.")
+    void getAuthentication_Success() {
+        // given
+        String token = jwtTokenProvider.createAccessToken(authentication);
+
+        // when
+        Authentication resultAuth = jwtTokenProvider.getAuthentication(token);
+
+        // then
+        assertThat(resultAuth.getName()).isEqualTo("testUser");
+        assertThat(resultAuth.getAuthorities().stream().map(GrantedAuthority::getAuthority)).containsExactly(Role.GUARDIAN.name());
+    }
+
+    @Test
+    @DisplayName("토큰에서 사용자 ID를 정상적으로 추출해야 한다.")
+    void getUserIdFromToken_Success() {
+        // given
+        String token = jwtTokenProvider.createAccessToken(authentication);
+
+        // when
+        String userId = jwtTokenProvider.getUserIdFromToken(token);
+
+        // then
+        assertThat(userId).isEqualTo("testUser");
+    }
+
+    @Test
+    @DisplayName("토큰의 만료 시간을 정상적으로 조회해야 한다.")
+    void getExpiration_Success() {
+        // given
+        String token = jwtTokenProvider.createAccessToken(authentication);
+
+        // when
+        Long expiration = jwtTokenProvider.getExpiration(token);
+
+        // then
+        assertThat(expiration).isNotNull().isGreaterThan(0L);
+    }
+}


### PR DESCRIPTION
# Redis를 이용한 리프레시 토큰 관리 및 JWT 토큰 테스트 코드 추가

## application-dev.yml 변동 사항
```
spring:
  datasource:
    url: jdbc:mysql://localhost:3306/ .......
    username: ......
    password: ......

  data:
    redis:
      host: localhost
      port: 6379

  jpa:
    hibernate:
      ddl-auto: update  # 또는 create, validate 등

jwt:
  secret: .........(랜덤 해시값)
  access-token-expiration-time: 3600000 # 1 시간
  refresh-token-expiration-time: 604800000 # 7 일
```

## 적용 및 변경 사항

- JWT 인증 방식 구현
- 로컬 Redis로 JWT 리프레시 토큰 관리
- test/.../auth/jwt/JwtSecretKeyGenerator.java 로 JWT 비밀 키 생성
- 로그인, 로그아웃 구현 (ID: 전화번호, PW: 비밀번호)
- 엑세스 토큰 재발급 구현 (리프레시 토큰 살아있을 시)
- 비밀번호 검증 내역 수정 (8자리, 숫자, 영어 필수 / 특수문자 선택)
- 테스트 코드 작성

