### PR TITLE
[Release] 14차 Release 및 CI/CD 테스트

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,6 +11,27 @@ jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
 
+    services:
+      mysql:
+        image: mysql:8.0
+        env:
+          MYSQL_ROOT_PASSWORD: ${{ secrets.DB_TEST_ROOT_PASSWORD }}
+          MYSQL_DATABASE: ${{ secrets.DB_TEST_NAME }}
+          MYSQL_USER: ${{ secrets.DB_TEST_USER }}
+          MYSQL_PASSWORD: ${{ secrets.DB_TEST_PASSWORD }}
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping --silent"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=3
+
+      redis:
+        image: redis:7
+        ports:
+          - 6379:6379
+
     steps:
       - name: Checkout source code
         uses: actions/checkout@v3
@@ -24,17 +45,16 @@ jobs:
       - name: Run tests
         working-directory: ./wecare-backend/wecare
         env:
-          DB_HOST: ${{ secrets.DB_HOST }}
-          DB_PORT: ${{ secrets.DB_PORT }}
-          DB_USER: ${{ secrets.DB_USER }}
-          DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
-          DB_NAME: ${{ secrets.DB_NAME }}
-          REDIS_HOST: ${{ secrets.REDIS_HOST }}
-          REDIS_PORT: ${{ secrets.REDIS_PORT }}
+          DB_TEST_HOST: ${{ secrets.DB_TEST_HOST }}
+          DB_TEST_USER: ${{ secrets.DB_TEST_USER }}
+          DB_TEST_PASSWORD: ${{ secrets.DB_TEST_PASSWORD }}
+          DB_TEST_ROOT_PASSWORD: ${{ secrets.DB_TEST_ROOT_PASSWORD }}
+          DB_TEST_NAME: ${{ secrets.DB_TEST_NAME }}
+          REDIS_TEST_HOST: ${{ secrets.REDIS_TEST_HOST }}
           JWT_SECRET: ${{ secrets.JWT_SECRET }}
           JWT_ACCESS_EXP: ${{ secrets.JWT_ACCESS_EXP }}
           JWT_REFRESH_EXP: ${{ secrets.JWT_REFRESH_EXP }}
-        run: ./gradlew clean test
+        run: ./gradlew clean test -Dspring.profiles.active=test
 
       - name: Build JAR
         working-directory: ./wecare-backend/wecare

--- a/wecare-backend/wecare/src/main/resources/application-test.yml
+++ b/wecare-backend/wecare/src/main/resources/application-test.yml
@@ -1,0 +1,13 @@
+spring:
+  datasource:
+    url: jdbc:mysql://${DB_TEST_HOST}:3306/${DB_TEST_NAME}
+    username: ${DB_TEST_USER}
+    password: ${DB_TEST_PASSWORD}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+  data:
+    redis:
+      host: ${REDIS_TEST_HOST}
+  sql:
+    init:
+      mode: always          # initialization-mode 대신 사용
+      schema-locations: classpath:schema.sql

--- a/wecare-backend/wecare/src/test/resources/schema.sql
+++ b/wecare-backend/wecare/src/test/resources/schema.sql
@@ -1,0 +1,132 @@
+-- 1. 사용자 테이블
+CREATE TABLE members
+(
+    id         BIGINT AUTO_INCREMENT PRIMARY KEY,
+    email      VARCHAR(30)  NOT NULL UNIQUE,
+    password   VARCHAR(100) NOT NULL,
+    name       VARCHAR(50)  NOT NULL,
+    gender     ENUM('MALE', 'FEMALE') NOT NULL,
+    birth_date DATETIME     NOT NULL,
+    phone      VARCHAR(20)  NOT NULL UNIQUE,
+    role       ENUM('GUARDIAN', 'DEPENDENT') NOT NULL,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+);
+
+-- 2. 초대 코드 테이블 (주석 처리 - Redis 사용 예정)
+-- CREATE TABLE invite_codes (
+--     id BIGINT AUTO_INCREMENT PRIMARY KEY,
+--     code VARCHAR(20) NOT NULL UNIQUE,
+--     inviter_id BIGINT NOT NULL,
+--     role_target ENUM('GUARDIAN', 'DEPENDENT') NOT NULL,
+--     is_used BOOLEAN DEFAULT FALSE,
+--     created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+--     expires_at DATETIME,
+--     CONSTRAINT fk_invite_codes_inviter FOREIGN KEY (inviter_id) REFERENCES members(id) ON DELETE CASCADE
+-- );
+
+-- 3. 보호자-피보호자 연결 테이블
+CREATE TABLE connections
+(
+    id           BIGINT AUTO_INCREMENT PRIMARY KEY,
+    protector_id BIGINT NOT NULL,
+    protected_id BIGINT NOT NULL,
+    connected_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    is_active    BOOLEAN  DEFAULT TRUE,
+    CONSTRAINT fk_connections_protector FOREIGN KEY (protector_id) REFERENCES members (id) ON DELETE CASCADE,
+    CONSTRAINT fk_connections_protected FOREIGN KEY (protected_id) REFERENCES members (id) ON DELETE CASCADE
+);
+
+-- 4. 루틴 테이블
+CREATE TABLE routines
+(
+    id          BIGINT AUTO_INCREMENT PRIMARY KEY,
+    member_id   BIGINT       NOT NULL,
+    type        ENUM('MEDICATION', 'SUPPLEMENT', 'CUSTOM') NOT NULL,
+    title       VARCHAR(100) NOT NULL,
+    description TEXT,
+    disease     VARCHAR(100),
+    shared      BOOLEAN  DEFAULT TRUE,
+    created_at  DATETIME DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT fk_routines_member FOREIGN KEY (member_id) REFERENCES members (id) ON DELETE CASCADE
+);
+
+-- 5. 루틴 체크 테이블
+CREATE TABLE routine_checks
+(
+    id         BIGINT AUTO_INCREMENT PRIMARY KEY,
+    routine_id BIGINT NOT NULL,
+    member_id  BIGINT NOT NULL,
+    checked_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT fk_routine_checks_routine FOREIGN KEY (routine_id) REFERENCES routines (id) ON DELETE CASCADE,
+    CONSTRAINT fk_routine_checks_member FOREIGN KEY (member_id) REFERENCES members (id) ON DELETE CASCADE
+);
+
+-- 6. 일정 테이블
+CREATE TABLE schedules
+(
+    id               BIGINT AUTO_INCREMENT PRIMARY KEY,
+    member_id        BIGINT       NOT NULL,
+    title            VARCHAR(100) NOT NULL,
+    description      TEXT,
+    date             DATETIME     NOT NULL,
+    time             TIME,
+    is_shared        BOOLEAN  DEFAULT TRUE,
+    is_alert_enabled BOOLEAN  DEFAULT FALSE,
+    created_at       DATETIME DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT fk_schedules_member FOREIGN KEY (member_id) REFERENCES members (id) ON DELETE CASCADE
+);
+
+-- 7. 건강 리포트 테이블
+CREATE TABLE health_reports
+(
+    id                  BIGINT AUTO_INCREMENT PRIMARY KEY,
+    member_id           BIGINT   NOT NULL,
+    report_date         DATETIME NOT NULL,
+    health_score_daily  INT,
+    health_score_weekly INT,
+    created_at          DATETIME DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT fk_health_reports_member FOREIGN KEY (member_id) REFERENCES members (id) ON DELETE CASCADE
+);
+
+-- 8. 처방전 테이블
+CREATE TABLE prescriptions
+(
+    id         BIGINT AUTO_INCREMENT PRIMARY KEY,
+    member_id  BIGINT       NOT NULL,
+    type       ENUM('MEDICATION', 'SUPPLEMENT') NOT NULL,
+    name       VARCHAR(100) NOT NULL,
+    method     TEXT,
+    start_date DATETIME,
+    end_date   DATETIME,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT fk_prescriptions_member FOREIGN KEY (member_id) REFERENCES members (id) ON DELETE CASCADE
+);
+
+-- 9. 만보계 테이블
+CREATE TABLE pedometers
+(
+    id         BIGINT AUTO_INCREMENT PRIMARY KEY,
+    member_id  BIGINT   NOT NULL,
+    date       DATETIME NOT NULL,
+    step_count INT      DEFAULT 0,
+    distance   FLOAT    DEFAULT 0,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT fk_pedometers_member FOREIGN KEY (member_id) REFERENCES members (id) ON DELETE CASCADE
+);
+
+-- 10. 알림 테이블
+CREATE TABLE alerts
+(
+    id          BIGINT AUTO_INCREMENT PRIMARY KEY,
+    member_id   BIGINT   NOT NULL,
+    alert_type  ENUM('ROUTINE', 'SCHEDULE', 'CUSTOM') NOT NULL,
+    title       VARCHAR(100),
+    content     TEXT,
+    alert_time  DATETIME NOT NULL,
+    repeat_flag BOOLEAN  DEFAULT FALSE,
+    sound_type  ENUM('DEFAULT', 'CUSTOM') DEFAULT 'DEFAULT',
+    voice_path  VARCHAR(255),
+    created_at  DATETIME DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT fk_alerts_member FOREIGN KEY (member_id) REFERENCES members (id) ON DELETE CASCADE
+);


### PR DESCRIPTION
# 하단 네비게이션버튼, 헤더 UI 업데이트 [권아영] #8
- 헤더 부분 오른쪽 버튼 2개 추가해야함
### 네비게이션 버튼 폰트, 굵기 수정완료
_이미지는 폰트, 굵기 수정 전_
<img width="1092" height="2072" alt="image" src="https://github.com/user-attachments/assets/2c546b79-1e76-473f-9e72-6e8f5c7f291d" />


# Security, + JWT, 사용자 도메인 관련 API 구현 및 테스트 [은택] #5, #9, #13 
### 적용 및 변경 사항
- JWT 인증 방식 구현
- 로컬 Redis로 JWT 리프레시 토큰 관리
- test/.../auth/jwt/JwtSecretKeyGenerator.java 로 JWT 비밀 키 생성
- 로그인, 로그아웃 구현 (ID: 전화번호, PW: 비밀번호)
- 로그아웃 시 토큰 폐기
- 엑세스 토큰 재발급 구현 (리프레시 토큰 살아있을 시)
- 비밀번호 검증 내역 수정 (8자리, 숫자, 영어 필수 / 특수문자 선택)
- 테스트 코드 작성
### 07.18 이슈 및 추후 변경 예정
- SMS 인증번호 방식 보류 (사업자 등록 필수로 확인 됨)
- 회원가입 시 전화번호 받지 않도록 변경
- ID를 전화번호가 아닌 memberID로 변경
- 테스트 코드 수정

# Swagger, Cors Configuration [태현] #4
- Swagger-ui 적용하여 /swagger-ui.html를 통해 API 명세 확인 가능
- CORS Config 추가, localhost:8080 uri는 cors 허용
# CICD 파이프라인 구축 및 EC2 배포 [태현] #14
### cicd: Spring CICD 파이프라인
- 모든 Credential 환경변수 github action에서 관리
- application.yml로 민감 환경변수 통합
- docker compose를 통해 EC2에 배포
- main 브랜치로 병합 시 Test 및 배포 자동화
### 파이프라인 오류 수정
- 상대경로 잘못 입력으로 인한 오류 수정 (3차 테스트)
- Spring Swagger 의존성 버전 명시 안됨으로 인한 오류 수정 (4차 테스트)
- 코드 수정 내용 commit 누락 (5차 테스트)
- git log 꼬인 것 정정 (6차 테스트)
- Test 패키지에 잘못 들어간 파일 수정 (7차 테스트)
- Redis 관련 환경변수 주석 처리 해체 (8차 테스트)
- 테스트 시 환경변수 적용 방식 변경 (9차 테스트)
- 누락된 환경변수 추가 (10차 테스트)
- .env 파일 생성 및 source로 시스템에 적용 (11차 테스트)
- 환경변수 바로 시스템에 주입, application.yml에 환경변수 관련 로깅 추가 (12차 테스트)
- 불필요한 test/resources/application.yml 제거 (13차 테스트)
- CI 중 Test에 필요한 Test용 mysql, redis 컨테이너, Test 시 자동으로 정의될 Schema 쿼리문 정의
### 배포
- NGINX + CERTBOT으로 HTTPS 적용 완료
- www.mobidic.shop 도메인 적용 예정 (과거 프로젝트에 쓰던 기한 많이 남는 도메인 사용)