### PR TITLE
[Release] 30차 Release 및 CI/CD 테스트

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,15 +42,10 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
 
-      - name: Network Test
-        run: |
-          echo "Testing DNS resolution..."
-          ping -c 3 mysql
-
       - name: Run tests
         working-directory: ./wecare-backend/wecare
         env:
-          DB_HOST: mysql
+          DB_HOST: localhost
           DB_USER: wecare_test
           DB_PASSWORD: wecareTest
           DB_ROOT_PASSWORD: password

--- a/wecare-backend/wecare/src/main/resources/application-test.yml
+++ b/wecare-backend/wecare/src/main/resources/application-test.yml
@@ -3,9 +3,9 @@ spring:
     hibernate:
       ddl-auto: update
   datasource:
-    url: jdbc:mysql://mysql:3306/wecare_test
-    username: wecare_test
-    password: wecareTest
+    url: jdbc:mysql://${DB_HOST}:${DB_PORT}/${DB_NAME}
+    username: ${DB_USER}
+    password: ${DB_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
 
   data:


### PR DESCRIPTION
# 하단 네비게이션버튼, 헤더 UI 업데이트 [아영] #8
- 헤더 부분 오른쪽 버튼 2개 추가해야함
### 네비게이션 버튼 폰트, 굵기 수정완료
_이미지는 폰트, 굵기 수정 전_
<img width="1092" height="2072" alt="image" src="https://github.com/user-attachments/assets/2c546b79-1e76-473f-9e72-6e8f5c7f291d" />


# Security, + JWT, 사용자 도메인 관련 API 구현 및 테스트 [은택] #5, #9, #13 
### 적용 및 변경 사항
- JWT 인증 방식 구현
- 로컬 Redis로 JWT 리프레시 토큰 관리
- test/.../auth/jwt/JwtSecretKeyGenerator.java 로 JWT 비밀 키 생성
- 로그인, 로그아웃 구현 (ID: 전화번호, PW: 비밀번호)
- 로그아웃 시 토큰 폐기
- 엑세스 토큰 재발급 구현 (리프레시 토큰 살아있을 시)
- 비밀번호 검증 내역 수정 (8자리, 숫자, 영어 필수 / 특수문자 선택)
- 테스트 코드 작성
### 07.18 이슈 및 추후 변경 예정
- SMS 인증번호 방식 보류 (사업자 등록 필수로 확인 됨)
- 회원가입 시 전화번호 받지 않도록 변경
- ID를 전화번호가 아닌 memberID로 변경
- 테스트 코드 수정

# Swagger, Cors Configuration [태현] #4
- Swagger-ui 적용하여 /swagger-ui.html를 통해 API 명세 확인 가능
- CORS Config 추가, localhost:8080 uri는 cors 허용
# CICD 파이프라인 구축 및 EC2 배포 [태현] #14
### cicd: Spring CICD 파이프라인
- 모든 Credential 환경변수 github action에서 관리
- application.yml로 민감 환경변수 통합
- docker compose를 통해 EC2에 배포
- main 브랜치로 병합 시 Test 및 배포 자동화
### 파이프라인 오류 수정
- 상대경로 잘못 입력으로 인한 오류 수정 (3차 테스트)
- Spring Swagger 의존성 버전 명시 안됨으로 인한 오류 수정 (4차 테스트)
- 코드 수정 내용 commit 누락 (5차 테스트)
- git log 꼬인 것 정정 (6차 테스트)
- Test 패키지에 잘못 들어간 파일 수정 (7차 테스트)
- Redis 관련 환경변수 주석 처리 해체 (8차 테스트)
- 테스트 시 환경변수 적용 방식 변경 (9차 테스트)
- 누락된 환경변수 추가 (10차 테스트)
- .env 파일 생성 및 source로 시스템에 적용 (11차 테스트)
- 환경변수 바로 시스템에 주입, application.yml에 환경변수 관련 로깅 추가 (12차 테스트)
- 불필요한 test/resources/application.yml 제거 (13차 테스트)
- CI 중 Test에 필요한 Test용 mysql, redis 컨테이너, Test 시 자동으로 정의될 Schema 쿼리문 정의 (14차 테스트)
- services 블럭엔 secrets 사용 불가로, 하드코딩 (15차 테스트)
- schema.sql 경로 변경 (16차 테스트)
- jpa 관련 ddl 자동생성 비활성화 (17차 테스트)
- MYSQL 초기 쿼리 확인용 로깅 추가 (18차 테스트)
- mysql credential 하드 코딩으로 변경 (19차 테스트)
- application-test.yml 오타 수정 (20차 테스트)
- $wecare_test => wecare_test, $mysql:// => mysql:// (21차 테스트)
- applocation-test.yml dialect 부분 제거 (22차 테스트)
- runtimeOnly => implementation으로 변경하여 테스트 환경에서도 사용 (23차 테스트)
- test 실행 시 디버깅 로그 출력 설정 (24차 테스트)
- application.yml 먼저 읽고 application-test.yml의 값을 덮어씌우는 문제 => application.yml에 정의되지 않은 환경변수를 사용하므로 해당 환경변수 부여 (25차 테스트)
- application.yml 포트 번호 환경변수 누락 (26차 테스트)
- --stacktrace 추가 (27차 테스트)
- DB 연결에 지속적인 접속 오류 발생.. 로그 추가적으로 확인 필요 (28차 테스트)
- debug: mysql hostname으로 접근 디버깅용 코드 : mysql 컨테이너 run 후 ping (29차 테스트)
- debug: mysql hostname 변경 : mysql:8080 => localhost:8080 (30차 테스트)
### 배포
- NGINX + CERTBOT으로 HTTPS 적용 완료
- www.mobidic.shop 도메인 적용 예정 (과거 프로젝트에 쓰던 기한 많이 남는 도메인 사용)