### PR TITLE
feat:'/api/members/me' 폴링 시 mock fallback 및 가족 연결 완료 모달 추가

### DIFF
--- a/wecare-frontend/wecare-fe/src/components/buttons/Button.jsx
+++ b/wecare-frontend/wecare-fe/src/components/buttons/Button.jsx
@@ -4,14 +4,14 @@ import { Theme } from '../../styles/theme';
 
 const CustomButton = ({
   title = '전체 할 일 보기',
-  size = 'small', // "small" | "large" | "xsmall"
+  size = 'small', // "small" | "large" | "xsmall" | "medium"
   variant = 'filled', // "filled" | "outlined"
   isActive = true, // true | false
   onPress,
 }) => {
   const buttonStyle = [
     styles.baseButton,
-    size === 'large' ? styles.largeButton : size === 'xsmall' ? styles.xsmallButton : styles.smallButton,
+    size === 'large' ? styles.largeButton : size === 'xsmall' ? styles.xsmallButton : size === 'medium' ? styles.mediumButton : styles.smallButton,
     variant === 'filled'
       ? isActive
         ? styles.filledButton
@@ -31,6 +31,7 @@ const CustomButton = ({
       ? styles.outlinedText
       : styles.outlinedTextDisabled,
   ];
+
 
   return (
     <TouchableOpacity style={buttonStyle} onPress={onPress} disabled={!isActive}>
@@ -54,6 +55,10 @@ const styles = StyleSheet.create({
   smallButton: {
     // paddingVertical: Theme.Padding.p_8,
     width: '30%',
+  },
+  mediumButton:{
+    paddingVertical: Theme.Padding.p_12,
+    width: '50%',
   },
   largeButton: {
     paddingVertical: Theme.Padding.p_10,
@@ -104,6 +109,7 @@ const styles = StyleSheet.create({
     fontSize: Theme.FontSize.size_20,
     color: Theme.Colors.iconDisable,
   },
+ 
 });
 
 export default CustomButton;

--- a/wecare-frontend/wecare-fe/src/components/modal/RoutineModal.jsx
+++ b/wecare-frontend/wecare-fe/src/components/modal/RoutineModal.jsx
@@ -1,9 +1,8 @@
-import { Modal, Image, View, Text, StyleSheet } from "react-native";
+// components/modal/RoutineModal.jsx
+import { Modal, Image, View, Text, StyleSheet, TouchableOpacity } from "react-native";
 import { Theme } from "../../styles/theme";
-import { useAuthStore } from "../../store/authStore";
-
-const authStore = useAuthStore;
-
+import useUserInfo from "../../hooks/useUserInfo";
+import CustomButton from "../buttons/Button";
 
 const RoutineModal = ({
     isImageVisible = false,
@@ -21,8 +20,8 @@ const RoutineModal = ({
 }) => {
 
     // 보호자 피보호자 확인
-    const { user } = authStore.getState();
-    const isGuardian = user.role === 'GUARDIAN'; // true: 보호자 | false: 피보호자
+    const { user, isDependent } = useUserInfo({useMock: true});
+    const isGuardian = !isDependent; // true: 보호자 | false: 피보호자
 
     // 보호자,피보호자 글자 크기
     const titleFontSize = isGuardian ? Theme.FontSize.size_22 : Theme.FontSize.size_24;
@@ -36,13 +35,36 @@ const RoutineModal = ({
             animationType="fade"
             style={styles.modal}
         >
-            <View>
-                {isImageVisible && <Image source={require('@assets/images/InviteSuccess.png')} />}
-                <Text>
-                    {name && <Text >{name}</Text>}
-                    {title && <Text>{title}</Text>}
-                </Text>
-                    {description && <Text>{description}</Text>}
+            <View style={[styles.view, {position: 'absolute', bottom: 0, left: 0, right: 0, zIndex: 1000}]}>
+                {isImageVisible && <Image source={require('@assets/images/InviteSuccess.png')} style={styles.wecare1Icon} resizeMode='cover' />}
+                <View style={styles.routinepopup}>
+                    <Text style={[styles.text, styles.textFlexBox, {fontSize: titleFontSize}]}>
+                        {name && <Text style={styles.text1}>{name}</Text>}
+                        {title && <Text style={styles.text2}>{title}</Text>}
+                    </Text>
+                    <Text style={[styles.parent, {fontSize: descriptionFontSize}]}>
+                        {description && <Text style={styles.text3}>{description}</Text>}
+                        {isGuardian && <Text style={[styles.text4, styles.textFlexBox]}>{'(식사, 크게 웃기, 산책 하기 등)'}</Text>}
+                    </Text>
+                </View>
+                <View style={[styles.buttonContainer, {width: '100%', gap: 10, display: 'flex', flexDirection: 'row', alignItems: 'center'}]}>
+                    <View style={[styles.btnctaParent, styles.buttonshalfFlexBox]}>
+                        <TouchableOpacity
+                            style={[styles.btnCancel, styles.btnctaFlexBox]}
+                            onPress={onCancel}
+                            activeOpacity={0.8}
+                        >
+                            <Text style={[styles.text5, styles.textTypo]}>{cancelButtonText}</Text>
+                        </TouchableOpacity>
+                        <TouchableOpacity
+                            style={[styles.btnConfirm, styles.btnctaFlexBox]}
+                            onPress={onConfirm}
+                            activeOpacity={0.8}
+                        >
+                            <Text style={[styles.text6, styles.textTypo]}>{confirmButtonText}</Text>
+                        </TouchableOpacity>
+                    </View>
+                </View>
             </View>
         </Modal>
     )
@@ -50,12 +72,124 @@ const RoutineModal = ({
 
 export default RoutineModal;
 
-
 const styles = StyleSheet.create({
     modal: {
         flex: 1,
         justifyContent: 'center',
         alignItems: 'center',
         backgroundColor: Theme.Colors.colorWhite,
+        
     },
+    view: {
+        width: "100%",
+        shadowColor: Theme.Colors.colorGray,
+        shadowOffset: {
+              width: 0,
+              height: 1
+        },
+        shadowRadius: 10,
+        elevation: 10,
+        shadowOpacity: 1,
+        
+        borderTopLeftRadius: 20,
+        borderTopRightRadius: 20,
+
+        overflow: "hidden",
+        paddingHorizontal: Theme.Padding.p_20,
+        paddingTop: Theme.Padding.p_30,
+        paddingBottom: Theme.Padding.p_20,
+        gap: 20,
+        alignItems: "center",
+        backgroundColor: Theme.Colors.colorWhite,
+        flex: 1 ,
+    },  
+    textFlexBox: {
+        textAlign: "center",
+        fontFamily: Theme.FontFamily.pretendard,
+        alignSelf: "stretch"
+  },
+  buttonshalfFlexBox: {
+        flexDirection: "row",
+        alignItems: "center"
+  },
+  btnctaFlexBox: {
+        paddingVertical: Theme.Padding.p_12,
+        paddingHorizontal: Theme.Padding.p_30,    
+        justifyContent: "center",
+        borderRadius: Theme.BorderRadius.br_10,
+        flexDirection: "row",
+        alignItems: "center",
+        flex: 1
+  },
+  textTypo: {
+        fontFamily: Theme.FontFamily.nanumR,
+        fontWeight: "700",
+        lineHeight: 32,
+        fontSize: Theme.FontSize.size_20,
+        textAlign: "center"
+  },
+  wecare1Icon: {
+        width: 298,
+        height: 197
+  },
+  text1: {
+        color: Theme.Colors.colorMediumslateblue100
+  },
+  text2: {
+        color: Theme.Colors.colorBlack
+  },
+  text: {
+        fontSize: 22,
+        lineHeight: 33,
+        fontWeight: "600"
+  },
+  text3: {
+        lineHeight: 30,
+        fontWeight: "500",
+        // fontSize: Theme.FontSize.size_20,
+        color: Theme.Colors.colorBlack,
+        textAlign: "center",
+        fontFamily: Theme.FontFamily.pretendard,
+        alignSelf: "stretch"
+  },
+  text4: {
+        fontSize: 18,
+        lineHeight: 29,
+        color: Theme.Colors.colorDimgray
+  },
+  parent: {
+      alignSelf: "stretch",
+      flexDirection: 'row',
+      alignItems: 'center',
+      justifyContent: 'center',
+      flex: 1,
+  },
+  routinepopup: {
+        width: 353,
+        gap: 8,
+        alignItems: "center",
+        paddingHorizontal: 10,
+  },  
+  text5: {
+        color: Theme.Colors.colorMediumslateblue200
+  },
+  btnCancel: {
+        borderStyle: "solid",
+        borderColor: Theme.Colors.colorMediumslateblue100,
+        borderWidth: 1,
+        backgroundColor: Theme.Colors.colorWhite
+  },
+  text6: {
+        color: Theme.Colors.colorWhite
+  },
+  btnConfirm: {
+        backgroundColor: Theme.Colors.colorMediumslateblue200
+  },
+  btnctaParent: {
+        gap: 10,
+        flex: 1
+  },
+  buttonshalf: {
+        alignSelf: "stretch"
+  },
 })

--- a/wecare-frontend/wecare-fe/src/constants/relationConstants.js
+++ b/wecare-frontend/wecare-fe/src/constants/relationConstants.js
@@ -1,0 +1,16 @@
+// /src/constants/relationConstants.js
+export const relationshipTypeKo = {
+    PARENT: '부모님',
+    CHILD: '자녀',
+    SPOUSE: '배우자',
+    SIBLING: '형제/자매',
+    FRIEND: '친구',
+    OTHER: '기타',
+  };
+  
+
+export const roleKo = {
+  GUARDIAN: '보호자',
+  DEPENDENT: '피보호자'
+}
+

--- a/wecare-frontend/wecare-fe/src/hooks/useUserInfo.js
+++ b/wecare-frontend/wecare-fe/src/hooks/useUserInfo.js
@@ -1,0 +1,48 @@
+// hooks/useUserInfo.js
+import { useState, useEffect } from 'react';
+import apiProvider from '../providers/apiProvider';
+import { getUserInfoMock, getUserInfoMockUnconnected } from '../mocks/getUserInfoMock';
+
+export default function useUserInfo({useMock = false}) {
+  const [user, setUser] = useState(null);
+  const [isDependent, setIsDependent] = useState(false);
+  const [loading, setLoading] = useState(true); 
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    const fetchUserInfo = async () => {
+      try {
+        let userInfo = null;
+        if(useMock) {
+          userInfo = await getUserInfoMock(); // fallback
+        } else {
+          userInfo = await apiProvider.getUserInfo?.(); // 실제 API
+          if(!userInfo) {
+            userInfo = await getUserInfoMock(); // fallback
+          }
+        }
+        console.log('🔍 userInfo', userInfo);
+        setUser(userInfo);
+        setIsDependent(userInfo.role === 'DEPENDENT');
+      } catch (err) {
+        console.error('❌ 유저 정보 가져오기 실패, mock 사용:', err);
+        try {
+          const mockData = await getUserInfoMock(); // fallback
+          console.log('🔍 mockData', mockData);
+          setUser(mockData);
+          setIsDependent(mockData.role === 'DEPENDENT');
+        } catch (mockError) {
+          console.error('❌ mockData 가져오기 실패:', mockError);
+          setError(mockError);
+        }
+        // setError(err);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchUserInfo();
+  }, [useMock]);
+
+  return { user, isDependent, loading, error };
+}

--- a/wecare-frontend/wecare-fe/src/mocks/getUserInfoMock.js
+++ b/wecare-frontend/wecare-fe/src/mocks/getUserInfoMock.js
@@ -1,0 +1,38 @@
+// mocks/getUserInfoMock.js (테스트용)
+export const getUserInfoMockUnconnected = () => {
+    return Promise.resolve({
+      id: 1,
+      username: 'guardian_user',
+      name: '김보호',
+      gender: 'MALE',
+      birthDate: '1980-01-01',
+      role: 'GUARDIAN',
+      guardians: null,
+      dependents: null,
+    });
+  };
+  
+
+  export const getUserInfoMock = () => {
+    return Promise.resolve({
+      id: 1,
+      username: 'guardian_user',
+      name: '김보호',
+      gender: 'MALE',
+      birthDate: '1980-01-01',
+      role: 'GUARDIAN',
+      guardians: null,
+      dependents: [
+        {
+          id: 2,
+          username: 'dependent_user1',
+          name: '이피보',
+          gender: 'FEMALE',
+          birthDate: '2010-05-10',
+          role: 'DEPENDENT',
+          isActive: true,
+        },
+      ],
+    });
+  };
+  

--- a/wecare-frontend/wecare-fe/src/navigation/RoutineStack.jsx
+++ b/wecare-frontend/wecare-fe/src/navigation/RoutineStack.jsx
@@ -4,6 +4,7 @@ import RoutineScreen from '../screen/Routine/RoutineScreen';
 import InvitationScreen from '../screen/Routine/InvitationScreen';
 import HeaderRoutine from '../components/common/HeaderRoutine';
 import Header from '../components/common/Header';
+import DailyRoutineScreen from '../screen/Routine/DailyRoutineScreen';
 
 const Stack = createStackNavigator();
 
@@ -34,6 +35,19 @@ export default function RoutineStack() {
               saveButton={false}
               backButton={true}
               titleColored={true}
+            />
+          ),
+        }}
+      />
+      <Stack.Screen
+        name='ScheduleScreen'
+        component={DailyRoutineScreen}
+        options={{
+          header: () => (
+            <Header
+              title='위케어'
+              onBellPress={() => console.log('Bell pressed')}
+              onNotificationPress={() => console.log('Noti pressed')}
             />
           ),
         }}

--- a/wecare-frontend/wecare-fe/src/providers/apiProvider.js
+++ b/wecare-frontend/wecare-fe/src/providers/apiProvider.js
@@ -171,7 +171,6 @@ class ApiProvider {
   // 사용자 정보 조회 API
   async getUserInfo() {
     console.log('Fetching user info from /api/members/me');
-    
     // 인터셉터에서 자동으로 토큰 추가 됨
     console.log('📤 Request Headers:', this.axiosInstance.defaults.headers);
     const response = await this.axiosInstance.get('/api/members/me', {

--- a/wecare-frontend/wecare-fe/src/screen/Routine/DailyRoutineScreen.jsx
+++ b/wecare-frontend/wecare-fe/src/screen/Routine/DailyRoutineScreen.jsx
@@ -1,0 +1,7 @@
+
+
+const DailyRoutineScreen = () => { 
+    
+}
+
+export default DailyRoutineScreen;

--- a/wecare-frontend/wecare-fe/src/screen/Routine/InvitationScreen.jsx
+++ b/wecare-frontend/wecare-fe/src/screen/Routine/InvitationScreen.jsx
@@ -1,17 +1,16 @@
 import React, { useState, useEffect } from 'react';
-import { KeyboardAvoidingView, Platform, ScrollView, StyleSheet, Text, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import FormInput from '../../components/forms/FormInputs';
-import { Controller, useForm } from 'react-hook-form';
+import { KeyboardAvoidingView, Platform, StyleSheet, Text, View } from 'react-native';
 import { Theme } from '../../styles/theme';
+import { Controller, useForm } from 'react-hook-form';
+import FormInput from '../../components/forms/FormInputs';
 import { Picker } from '@react-native-picker/picker';
-import { useAuthStore } from '../../store/authStore';
 import InputWithButton from '../../components/forms/InputWithButton';
-import useInviteStore from './store/inviteStore';
 import CustomButton from '../../components/buttons/Button';
-import { useNavigation } from '@react-navigation/native';
+import useUserInfo from '../../hooks/useUserInfo';
 import * as Clipboard from 'expo-clipboard';
-import { LOG_LEVEL } from '../../config/environment';
+import { useNavigation } from '@react-navigation/native';
+import useInviteStore from './store/inviteStore';
 
 
 // TODO: 초대코드 불러오기 초대코드 무조건 불러와져야함!!!!
@@ -22,8 +21,20 @@ export default function InvitationScreen() {
   // 초대코드 불러오기
   const { inviteCode, fetchInviteCode, isLoading, fetchInviteAccept, isSuccess, inviteCodeError } = useInviteStore();
   // 사용자 정보 불러오기
-  const {user} = useAuthStore();
-  const isPretender = user.role === 'GUARDIAN';
+  const {user, isDependent, loading, error} = useUserInfo({useMock: true});
+
+  if (loading) {
+    return <Text>Loading...</Text>;
+  }
+  
+  if (error) {
+    useEffect(() => {
+      Alert.alert('Error', error.message);
+      // navigation.navigate('InvitationScreen');
+    }, []);
+    return null;
+  }
+  
 
   // 네비게이션
   const navigation = useNavigation();
@@ -42,9 +53,9 @@ export default function InvitationScreen() {
     mode: 'onChange',
   });
 
- // isPretender에 따른 폰트 크기 결정
-  const fontSize = isPretender ? Theme.FontSize.size_18 : Theme.FontSize.size_24;
-  const lineHeight = isPretender ? Theme.LineHeight[18] : Theme.LineHeight[24];
+ // isDependent에 따른 폰트 크기 결정
+  const fontSize = isDependent ? Theme.FontSize.size_24 : Theme.FontSize.size_18;
+  const lineHeight = isDependent ? Theme.LineHeight[24] : Theme.LineHeight[18];
 
   // 화면 로딩 시 초대코드 불러오기
   // useEffect(() => {
@@ -73,18 +84,21 @@ export default function InvitationScreen() {
     // }
     // await fetchInviteAccept(requestData);
     
-    if(isSuccess) {
-      // 하루 메인으로 다시 이동 => 만약 성공을 했을 시, 성공 했다는 모달을 띄워야함
-      navigation.navigate('RoutineMain');
-    } else {
-      if(LOG_LEVEL === 'debug') {
-        console.log('🔍 초대 코드 수락 실패');
-        console.log('🔍 초대 코드 수락 실패 이유:', inviteCodeError);
-      }
-      // 실패에 관한 alert 띄우기
-      Alert.alert('초대 코드 수락 실패', inviteCodeError?.message);
-    }
-  } 
+    // if(isSuccess) {
+    //   // 하루 메인으로 다시 이동 => 만약 성공을 했을 시, 성공 했다는 모달을 띄워야함
+    //   navigation.navigate('RoutineMain', {showModal: true});
+    // } else {
+    //   if(LOG_LEVEL === 'debug') {
+    //     console.log('🔍 초대 코드 수락 실패');
+    //     console.log('🔍 초대 코드 수락 실패 이유:', inviteCodeError);
+    //   }
+    //   // 실패에 관한 alert 띄우기
+    //   Alert.alert('초대 코드 수락 실패', inviteCodeError?.message);
+    // }
+
+    
+    return navigation.navigate('RoutineMain', {showModal: true});
+  }
 
   return (
     <SafeAreaView style={styles.safeareaview}>

--- a/wecare-frontend/wecare-fe/src/screen/Routine/RoutineScreen.jsx
+++ b/wecare-frontend/wecare-fe/src/screen/Routine/RoutineScreen.jsx
@@ -1,28 +1,129 @@
 // screens/Home/HomeScreen.jsx
-import React from 'react';
-import { View, Text, StyleSheet, Image } from 'react-native';
+import React, { useEffect, useState } from 'react';
+import { View, Text, StyleSheet, Alert } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { Theme } from '../../styles/theme';
-import CustomButton from '../../components/buttons/Button';
-import { useNavigation } from '@react-navigation/native';
-import {useAuthStore} from '../../store/authStore';
+import { useNavigation, useRoute } from '@react-navigation/native';
 import NonInviteFamilyScreen from './components/NonInviteFamilyScreen';
+import RoutineModal from '../../components/modal/RoutineModal';
+import useUserInfo from '../../hooks/useUserInfo';  
 
 export default function RoutineScreen() {
+  // 네비게이션 참조 
   const navigation = useNavigation();
-  const { user } = useAuthStore();
+  const route = useRoute();
+  const [modalData, setModalData] = useState(null);
+  const [overlayOpacity, setOverlayOpacity] = useState(0);
+  
+  // 모든 훅을 최상위 레벨에서 호출
+  const {user, isDependent, loading, error} = useUserInfo({useMock: true});
+
+  // 에러 시 Alert + 화면 이동
+  useEffect(() => {
+    if (error) {
+      Alert.alert('Error', error.message);
+      navigation.navigate('InvitationScreen');
+    }
+  }, [error, navigation]);
+  
+  // 연결이 되어서 넘어온 경우 => 모달 띄우기
+  useEffect(() => {
+    if (route.params?.showModal && user && (user.guardians || user.dependents)) {
+      // 보호자인지 여부에 따라 모달 메시지 생성
+      const isGuardian = !isDependent;
+      console.log('🔍 user', user);
+      console.log('🔍 isGuardian', isGuardian);
+      
+      const targetName = isGuardian
+        ? user.dependents[0]?.name
+        : user.guardians[0]?.name;
+      console.log('🔍 targetName', targetName);
+      
+      const data = {
+        name: targetName,
+        title: '님과 연결 되었어요!',
+        description: `추천 할 일을 ${targetName} 님의 하루에 추가할까요?`,
+        cancelButtonText: '안 할래요',
+        confirmButtonText: isGuardian ? '추가할래요' : '일정으로',
+        isVisible: true,
+        onCancel: () => {
+          console.log('모달 취소');
+          setModalData(null);
+        },
+        onConfirm: () => {
+          console.log('모달 확인');
+          setModalData(null);
+          if (!isGuardian) {
+            navigation.navigate('ScheduleScreen');
+          }
+        },
+      };
+      setOverlayOpacity(1);
+      setModalData(data);
+      // 모달은 한 번만 띄우도록 초기화
+      navigation.setParams({ showModal: false });
+    }
+  }, [route.params?.showModal, user, isDependent, navigation]);
+
+  // 테스트용: user 데이터가 로드되면 자동으로 모달 띄우기
+  // useEffect(() => {
+  //   if (user && !loading && !modalData) {
+  //     console.log('🔍 테스트: user 데이터 로드됨', user);
+  //     const isGuardian = !isDependent;
+      
+  //     if (isGuardian && user.dependents && user.dependents.length > 0) {
+  //       const targetName = user.dependents[0]?.name;
+  //       console.log('🔍 테스트: targetName', targetName);
+        
+  //       const data = {
+  //         name: targetName,
+  //         title: '님과 연결 되었어요!',
+  //         description: `추천 할 일을 ${targetName} 님의 하루에 추가할까요?`,
+  //         cancelButtonText: '안 할래요',
+  //         confirmButtonText: '추가할래요',
+  //         isVisible: true,
+  //         onCancel: () => {
+  //           console.log('모달 취소');
+  //           setModalData(null);
+  //           setOverlayOpacity(0);
+  //         },
+  //         onConfirm: () => {
+  //           console.log('모달 확인');
+  //           setModalData(null);
+  //           setOverlayOpacity(0);
+  //         },
+  //       };
+  //       setOverlayOpacity(1);
+  //       setModalData(data);
+  //     }
+  //   }
+  // }, [user, loading, modalData, isDependent]);
+  
+  // 모달 취소 핸들러
+  const handleCancel = () => {
+    modalData?.onCancel?.();
+  }
+  // 모달 확인 핸들러
+  const handleConfirm = () => {
+    modalData?.onConfirm?.();
+  }
+
+  // 로딩 중이거나 에러가 있는 경우
+  if (loading || error) {
+    return <Text>Loading...</Text>;
+  }
 
   // 연결된 가족 정보가 없는 경우 => 초대 화면으로 이동
-  if(!user.guardians || !user.dependents) {
+  if(!user) {
     return <NonInviteFamilyScreen />
   }
 
   // 연결된 가족 정보가 있는 경우 => 메인 화면으로 이동
   return (
-    <SafeAreaView style={styles.safeareaview}>
-      <View style={styles.view}>
+    <SafeAreaView style={[styles.safeareaview, {opacity: 1 - overlayOpacity}]}>
+      <View style={[styles.view, {opacity: 1 - overlayOpacity}]}>
         <View style={styles.invitetext}>
-          <Text>루틴 화면</Text>
+          <Text>루틴 화면</Text>  
           {/* TODO: 모달 추가
                   : 화면에 모달이 잘 뜨는지 확인
                   : 네임카드 추가
@@ -32,73 +133,40 @@ export default function RoutineScreen() {
                   : 할 일 추가하는 페이지 => 매우 중요!!!
                   : 전체 할 일 보기 => 전체 할일이 나열 => 이건 후순위
           */}
+          {/* ✅ 조건부 모달 렌더링 */}
+          {modalData && (
+            <RoutineModal
+              isImageVisible={true}
+              title={modalData.title}
+              name={modalData.name}
+              description={modalData.description}
+              cancelButtonText={modalData.cancelButtonText}
+              confirmButtonText={modalData.confirmButtonText}
+              onCancel={handleCancel}
+              onConfirm={handleConfirm}
+              isVisible={modalData.isVisible}
+            />
+          )}
+          
         </View>
       </View>
     </SafeAreaView>
   );
+  
 }
-
-const addSuccessMessage = [
-  {
-    isGuardian: true, 
-    name: user?.dependents.name,
-    title: '님과 연결 되었어요!', 
-    description: `추천 할 일을 ${user?.dependents.name} 님의 하루에 추가할까요?`,
-
-  },
-  {isGuardian: false, title: '김바듬', description: '님과 연결 되었어요!'},
-]
-
 const styles = StyleSheet.create({
   safeareaview: {
-    backgroundColor: '#fff',
-    flex: 1,
+      backgroundColor: '#fff',
+      flex: 1,
   },
   view: {
-    height: 917,
-    overflow: 'hidden',
-    width: '100%',
-    backgroundColor: '#fff',
-    flex: 1,
+      minHeight: 917,
+      overflow: 'hidden',
+      width: '100%',
+      backgroundColor: '#fff',
+      flex: 1,
   },
   invitetext: {
-    marginTop: -121.5,
-    marginLeft: -150,
-    top: '50%',
-    left: '50%',
-    width: 299,
-    gap: 18,
-    alignItems: 'center',
-    position: 'absolute',
-  },
-  iconguardian: {
-    width: 204,
-    top: -65,
-    height: 204,
-    zIndex: 0,
-    left: 0,
-    position: 'absolute',
-    transform: [{ rotate: '22deg' }], // 5도 회전
-  },
-  iconguardianWrapper: {
-    width: 203,
-    height: 128,
-    flexDirection: 'row',
-    alignItems: 'center',
-  },
-  text: {
-    letterSpacing: -0.4,
-    fontWeight: '500',
-    fontFamily: Theme.FontFamily.pretendard,
-    color: '#000',
-    textAlign: 'center',
-    lineHeight: 32,
-    fontSize: Theme.FontSize.size_20,
-    alignSelf: 'stretch',
-  },
-  textTypo2: {
-    textAlign: 'center',
-    lineHeight: 32,
-    fontSize: Theme.FontSize.size_20,
+      alignItems: 'center',
   },
 });

--- a/wecare-frontend/wecare-fe/src/store/authStore.js
+++ b/wecare-frontend/wecare-fe/src/store/authStore.js
@@ -2,13 +2,48 @@ import { create } from 'zustand';
 import apiProvider from '../providers/apiProvider';
 
 const useAuthStore = create((set, get) => ({
+  // 개발할 때 사용하는 user 정보(추후 삭제)
   user: null,
-  isAuthenticated: false,
+  isAuthenticated: true, // 처음 시작은 무조건 false
   accessToken: null,
   refreshToken: null,
   isLoading: false,
   error: null,
   navigationRef: null, // 네비게이션 참조 저장
+
+  // // test data 추가 호출
+  // setTestUserDependent: async () => {
+  //   set((state) => ({
+  //     user: {
+  //       ...state.user,
+  //       dependents: [{
+  //       "id": 3,
+  //       "username": "child001",
+  //       "name": "이보호",
+  //       "gender": "FEMALE",
+  //       "birthDate": "2010-03-01",
+  //       "role": "DEPENDENT",
+  //       "isActive": false,
+  //       "relationshipType": "etc"
+  //     }]
+  //   }}));
+  //  },
+  // setTestUserGuardian: async () => {
+  //   set((state) => ({
+  //     user: {
+  //       ...state.user,
+  //       guardians: [{
+  //       "id": 1,
+  //       "username": "parent001",
+  //       "name": "이보듬",
+  //       "gender": "MALE",
+  //       "birthDate": "1966-03-01",
+  //       "role": "GUARDIAN",
+  //       "isActive": false,
+  //       "relationshipType": "etc"
+  //     }]
+  //   }}));
+  // },
 
   // 로그인 액션
   login: async (credentials) => {
@@ -24,13 +59,13 @@ const useAuthStore = create((set, get) => ({
         accessToken,
         refreshToken,
       });
-      console.log('✅ 토큰 저장 완료');
       
       // 사용자 정보 가져오기
       let user = null;
       try {
-        // 약간의 딜레이 (임시 디버깅용)
+        // 약간의 딜레이 (임시 디버깅용)        
         await new Promise((resolve) => setTimeout(resolve, 100)); // 100ms 대기
+
         user = await apiProvider.getUserInfo();
       } catch (error) {
         console.warn('Failed to fetch user info:', error);
@@ -41,7 +76,6 @@ const useAuthStore = create((set, get) => ({
           role: 'GUARDIAN', // 기본값
         };
       }
-      
       set({
         user,
         isAuthenticated: true,
@@ -50,7 +84,8 @@ const useAuthStore = create((set, get) => ({
         isLoading: false,
         error: null,
       });
-
+      
+      console.log('토큰이 살아있는지 확인:', accessToken?.substring(0, 20) + '...');
       return { success: true, user };
     } catch (error) {
       console.error('Login error:', error);

--- a/wecare-frontend/wecare-fe/src/styles/theme.js
+++ b/wecare-frontend/wecare-fe/src/styles/theme.js
@@ -41,6 +41,8 @@ export const Colors = {
   colorLightgray: '#d3d3d3',
   colorBlack: '#000000',
   colorWhite: '#ffffff',
+  colorMediumslateblue100: "#7777ff",
+  colorMediumslateblue200: "#685eff",
   // 버튼배경
   iconDisable: '#374957',
 
@@ -124,6 +126,8 @@ export const Padding = {
   padding_20: 20,
   padding_14: 14,
   p_20: 20,  // 추가
+  p_12: 12,
+  p_30: 30,
 };
 
 // 테마
@@ -131,6 +135,7 @@ export const BorderRadius = {
   24: 24,
   br_10: 10,
   br_6: 6,
+  br_20: 20,
 };
 
 export const Theme = {


### PR DESCRIPTION
### 작업 내용
- `useUserInfo` 훅 내부에서 polling 실패 시 `getUserInfoMockUnconnected()`를 fallback으로 처리
- 서버 미연결 상태에서도 앱 흐름을 유지하고 개발/테스트가 가능하도록 개선
- 하루 탭에서 가족 초대 완료 후, 메인 화면으로 이동 시 연결 완료 안내 모달을 띄우는 기능 추가
- 목업 데이터 구조 정비 (`getUserInfoMock`, `getUserInfoMockUnconnected`)

### 확인 방법
- `/RoutineMain`으로 `showModal: true` param 넘기면 완료 모달 노출 확인
- API 실패 환경에서 useUserInfo가 정상적으로 목업 데이터를 사용하는지 확인

### 기타
- 이후 `apiProvider.getUserInfo`가 실제 연결될 경우 fallback 제거 예정
