### PR TITLE
feat: 관계 조회용 API 구현 및 DTO 분리

### DIFF
--- a/wecare-backend/wecare/src/main/java/com/example/wecare/member/controller/MemberController.java
+++ b/wecare-backend/wecare/src/main/java/com/example/wecare/member/controller/MemberController.java
@@ -1,6 +1,7 @@
 package com.example.wecare.member.controller;
 
 import com.example.wecare.member.dto.MemberResponse;
+import com.example.wecare.member.dto.MemberRelationshipDto;
 import com.example.wecare.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -22,5 +23,12 @@ public class MemberController {
     public ResponseEntity<MemberResponse> getMe() {
         MemberResponse memberResponse = memberService.getMe();
         return ResponseEntity.ok(memberResponse);
+    }
+
+    // 현재 로그인한 사용자와 연결된 모든 관계 정보를 조회
+    @GetMapping("/me/relationships")
+    public ResponseEntity<List<MemberRelationshipDto>> getMyRelationships() {
+        List<MemberRelationshipDto> relationships = memberService.getMemberRelationships();
+        return ResponseEntity.ok(relationships);
     }
 }

--- a/wecare-backend/wecare/src/main/java/com/example/wecare/member/domain/Member.java
+++ b/wecare-backend/wecare/src/main/java/com/example/wecare/member/domain/Member.java
@@ -56,11 +56,13 @@ public class Member {
     @Column(name = "updated_at")
     private LocalDateTime updatedAt;
 
-    @OneToMany(mappedBy = "guardian", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "guardian", cascade = CascadeType.ALL)
     @Builder.Default
+    @org.hibernate.annotations.SQLRestriction("is_active = true")
     private Set<Invitation> dependentConnections = new HashSet<>();
 
-    @OneToMany(mappedBy = "dependent", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "dependent", cascade = CascadeType.ALL)
     @Builder.Default
+    @org.hibernate.annotations.SQLRestriction("is_active = true")
     private Set<Invitation> guardianConnections = new HashSet<>();
 }

--- a/wecare-backend/wecare/src/main/java/com/example/wecare/member/dto/MemberRelationshipDto.java
+++ b/wecare-backend/wecare/src/main/java/com/example/wecare/member/dto/MemberRelationshipDto.java
@@ -1,0 +1,14 @@
+package com.example.wecare.member.dto;
+
+import com.example.wecare.invitation.domain.RelationshipType;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+public class MemberRelationshipDto {
+    private Long memberId;
+    private String relationshipType;
+}


### PR DESCRIPTION
- 관계 조회용 API 구현 및 DTO 분리

```json
GET /api/members/me/relationships

[
  {
    "memberId": 0,
    "relationshipType": "string"
  },
  {
    "memberId": 1,
    "relationshipType": "string"
  },
]
```