### PR TITLE
[Release] 7차 Release

### DIFF
--- a/wecare-backend/wecare/src/main/java/com/example/wecare/auth/controller/AuthController.java
+++ b/wecare-backend/wecare/src/main/java/com/example/wecare/auth/controller/AuthController.java
@@ -5,6 +5,10 @@ import com.example.wecare.auth.dto.LoginResponse;
 import com.example.wecare.auth.dto.SignUpRequest;
 import com.example.wecare.auth.jwt.JwtUtil;
 import com.example.wecare.auth.service.AuthService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -13,23 +17,41 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequestMapping("/api/auth")
 @RequiredArgsConstructor
+@Tag(name = "인증 서비스", description = "사용자 인증, 가입 등")
 public class AuthController {
     private final AuthService authService;
     private final JwtUtil jwtUtil;
 
+    @Operation(
+            summary = "회원가입",
+            description = ""
+    )
     @PostMapping("/signup")
     public ResponseEntity<String> signUp(@Valid @RequestBody SignUpRequest request) {
         return ResponseEntity.ok(authService.signUp(request) + " 회원가입이 완료되었습니다.");
     }
 
+    @Operation(
+            summary = "로그인",
+            description = ""
+    )
     @PostMapping("/login")
     public ResponseEntity<LoginResponse> login(@Valid @RequestBody LoginRequest loginRequest) {
         return ResponseEntity.ok(authService.login(loginRequest));
     }
 
+    @Operation(
+            summary = "로그아웃",
+            description = "Refresh-Token 헤더에 토큰 첨부 필요",
+            security = {
+                    @SecurityRequirement(name = "Authorization"),
+                    @SecurityRequirement(name = "Refresh-Token")}
+    )
     @PostMapping("/logout")
     public ResponseEntity<String> logout(
+            @Parameter(hidden = true)
             @RequestHeader("Authorization") String accessBearerToken,
+            @Parameter(hidden = true)
             @RequestHeader("Refresh-Token") String refreshBearerToken
     ) {
         String accessToken = accessBearerToken.substring(7);
@@ -41,9 +63,18 @@ public class AuthController {
         return ResponseEntity.ok("로그아웃 되었습니다.");
     }
 
+    @Operation(
+            summary = "엑세스 토큰 재발급",
+            description = "Refresh-Token 헤더에 토큰 첨부 필요",
+            security = {
+                    @SecurityRequirement(name = "Authorization"),
+                    @SecurityRequirement(name = "Refresh-Token")}
+    )
     @PostMapping("/reissue")
     public ResponseEntity<LoginResponse> reissue(
+            @Parameter(hidden = true)
             @RequestHeader("Authorization") String accessBearerToken,
+            @Parameter(hidden = true)
             @RequestHeader("Refresh-Token") String refreshBearerToken
     ) {
         String accessToken = accessBearerToken.substring(7);

--- a/wecare-backend/wecare/src/main/java/com/example/wecare/common/config/SwaggerConfig.java
+++ b/wecare-backend/wecare/src/main/java/com/example/wecare/common/config/SwaggerConfig.java
@@ -1,6 +1,7 @@
 package com.example.wecare.common.config;
 
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeIn;
 import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
 import io.swagger.v3.oas.annotations.security.SecurityScheme;
 import io.swagger.v3.oas.annotations.servers.Server;
@@ -17,11 +18,18 @@ import org.springframework.context.annotation.Configuration;
         })
 @Configuration
 @SecurityScheme(
-        name = "bearerAuth",
+        name = "Authorization",
         type = SecuritySchemeType.HTTP,
         scheme = "bearer",
         bearerFormat = "JWT",
-        description = "JWT Authorization"
+        description = "토큰 원본 사용 (Bearer 없이)"
+)
+@SecurityScheme(
+        name = "Refresh-Token",
+        type = SecuritySchemeType.APIKEY,
+        in = SecuritySchemeIn.HEADER,
+        paramName = "Refresh-Token",
+        description = "접미사로 \"Bearer \" 추가해야 함 (공백 주의)"
 )
 public class SwaggerConfig {
     @Bean

--- a/wecare-backend/wecare/src/main/java/com/example/wecare/connection/controller/ConnectionController.java
+++ b/wecare-backend/wecare/src/main/java/com/example/wecare/connection/controller/ConnectionController.java
@@ -3,6 +3,9 @@ package com.example.wecare.connection.controller;
 import com.example.wecare.connection.dto.ConnectionDto;
 import com.example.wecare.connection.dto.UpdateRelationRequest;
 import com.example.wecare.connection.service.ConnectionService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -13,29 +16,37 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/connections")
 @RequiredArgsConstructor
+@Tag(name = "사용자 연결 서비스", description = "보호자, 비보호자 간 연결")
 public class ConnectionController {
     private final ConnectionService connectionService;
 
+    @Operation(
+            summary = "내 연결 정보 리스트 조회",
+            description = "",
+            security = @SecurityRequirement(name = "Authorization")
+    )
     @GetMapping("")
     public ResponseEntity<List<ConnectionDto>> getMyConnections() {
         return ResponseEntity.ok(connectionService.getMyConnections());
     }
 
-    @PatchMapping("/{targetUserId}/deactivate")
-    public ResponseEntity<String> deactivateConnection(@PathVariable Long targetUserId) {
-        connectionService.deactivateConnection(targetUserId);
+    @Operation(
+            summary = "연결 해제하기",
+            description = "Soft-delete, 다시 연결 가능하며 데이터 보존됨",
+            security = @SecurityRequirement(name = "Authorization")
+    )
+    @PatchMapping("/{connectionId}/deactivate")
+    public ResponseEntity<String> deactivateConnection(@PathVariable Long connectionId) {
+        connectionService.deactivateConnection(connectionId);
 
         return ResponseEntity.ok("연결이 해제되었습니다.");
     }
 
-    @PatchMapping("/{targetUserId}/reactivate")
-    public ResponseEntity<String> reactivateConnection(@PathVariable Long targetUserId) {
-        connectionService.reactivateConnection(targetUserId);
-
-        return ResponseEntity.ok("연결이 재개 되었습니다.");
-    }
-
-    // 연결 정보 수정 ex) 보호자, 피보호자 간 관계 (가족, 친구 등)
+    @Operation(
+            summary = "연결 정보 수정",
+            description = "연결 간 관계 재설정",
+            security = @SecurityRequirement(name = "Authorization")
+    )
     @PatchMapping("/{connectionId}")
     public ResponseEntity<String> relationshipConnection(
             @PathVariable Long connectionId,

--- a/wecare-backend/wecare/src/main/java/com/example/wecare/invitation/controller/InvitationController.java
+++ b/wecare-backend/wecare/src/main/java/com/example/wecare/invitation/controller/InvitationController.java
@@ -3,6 +3,8 @@ package com.example.wecare.invitation.controller;
 import com.example.wecare.invitation.dto.AcceptInvitationRequest;
 import com.example.wecare.invitation.dto.InvitationDto;
 import com.example.wecare.invitation.service.InvitationService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -13,12 +15,22 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 public class InvitationController {
     private final InvitationService invitationService;
-
+    
+    @Operation(
+            summary = "초대 코드 생성",
+            description = "본인의 초대 코드 생성, 유효 시간 10분",
+            security = @SecurityRequirement(name = "Authorization")
+    )
     @GetMapping("/generate")
     public ResponseEntity<InvitationDto> generateInvitationCode() {
         return ResponseEntity.ok(invitationService.getInvitationCode());
     }
 
+    @Operation(
+            summary = "초대 코드 수락",
+            description = "상대방의 초대 코드를 수락하여 연결 수립",
+            security = @SecurityRequirement(name = "Authorization")
+    )
     @PostMapping("/accept")
     public ResponseEntity<String> acceptInvitationCode(
             @Valid @RequestBody AcceptInvitationRequest request

--- a/wecare-backend/wecare/src/main/java/com/example/wecare/member/controller/MemberController.java
+++ b/wecare-backend/wecare/src/main/java/com/example/wecare/member/controller/MemberController.java
@@ -3,6 +3,8 @@ package com.example.wecare.member.controller;
 import com.example.wecare.member.dto.MemberResponse;
 import com.example.wecare.member.dto.PartnerResponse;
 import com.example.wecare.member.service.MemberService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -16,11 +18,21 @@ import org.springframework.web.bind.annotation.RestController;
 public class MemberController {
     private final MemberService memberService;
 
+    @Operation(
+            summary = "내 정보 조회",
+            description = "사용자 정보 조회",
+            security = @SecurityRequirement(name = "Authorization")
+    )
     @GetMapping("/me")
     public ResponseEntity<MemberResponse> getMe() {
         return ResponseEntity.ok(memberService.getMe());
     }
 
+    @Operation(
+            summary = "연결된 상대방 정보 조회",
+            description = "민감 정보는 제외되며, 연결되지 않은 상대방은 조회 불가",
+            security = @SecurityRequirement(name = "Authorization")
+    )
     @GetMapping("/partner")
     public ResponseEntity<PartnerResponse> getPartner(
             @RequestParam Long partnerId

--- a/wecare-backend/wecare/src/main/java/com/example/wecare/routine/controller/RoutineController.java
+++ b/wecare-backend/wecare/src/main/java/com/example/wecare/routine/controller/RoutineController.java
@@ -6,6 +6,8 @@ import com.example.wecare.routine.dto.RoutineHistoryDto;
 import com.example.wecare.routine.dto.RoutineRepeatDayDto;
 import com.example.wecare.routine.dto.RoutineRequest;
 import com.example.wecare.routine.service.RoutineService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -18,6 +20,11 @@ import java.util.List;
 public class RoutineController {
     private final RoutineService routineService;
 
+    @Operation(
+            summary = "피보호자 루틴 목록 조회",
+            description = "피보호자 본인 또는 연결된 보호자만 피보호자의 식별자를 통해 접근 가능",
+            security = @SecurityRequirement(name = "Authorization")
+    )
     @GetMapping("/{dependentId}")
     public ResponseEntity<List<RoutineDto>> getRoutinesByDependentId(
             @PathVariable Long dependentId
@@ -25,6 +32,11 @@ public class RoutineController {
         return ResponseEntity.ok(routineService.getRoutinesByDependentId(dependentId));
     }
 
+    @Operation(
+            summary = "루틴 반복 데이터 조회",
+            description = "피보호자 본인 또는 연결된 보호자만 루틴의 식별자를 통해 접근 가능",
+            security = @SecurityRequirement(name = "Authorization")
+    )
     @GetMapping("/{routineId}")
     public ResponseEntity<List<RoutineRepeatDayDto>> getRepeatDaysByRoutineId(
             @PathVariable Long routineId
@@ -32,6 +44,11 @@ public class RoutineController {
         return ResponseEntity.ok(routineService.getRepeatDaysByRoutineId(routineId));
     }
 
+    @Operation(
+            summary = "사용자 루틴 수행 기록 조회",
+            description = "루틴의 성공 여부(COMPLETED, FAILED)와 수행 시간 조회 가능",
+            security = @SecurityRequirement(name = "Authorization")
+    )
     @GetMapping("/{memberId}/member_histories")
     public ResponseEntity<List<RoutineHistoryDto>> getRoutineHistoryByMemberId(
             @PathVariable Long memberId
@@ -39,6 +56,11 @@ public class RoutineController {
         return ResponseEntity.ok(routineService.getHistoriesByMemberId(memberId));
     }
 
+    @Operation(
+            summary = "특정 루틴의 수행 기록 조회",
+            description = "루틴의 식별자를 통해 해당 루틴의 수행 기록 조회",
+            security = @SecurityRequirement(name = "Authorization")
+    )
     @GetMapping("/{routineId}/routine_histories")
     public ResponseEntity<List<RoutineHistoryDto>> getRoutineHistoryByRoutineId(
             @PathVariable Long routineId
@@ -46,6 +68,11 @@ public class RoutineController {
         return ResponseEntity.ok(routineService.getHistoriesByRoutineId(routineId));
     }
 
+    @Operation(
+            summary = "루틴 생성",
+            description = "보호자만 피보호자의 식별자를 통해 접근 가능",
+            security = @SecurityRequirement(name = "Authorization")
+    )
     @PostMapping("/{dependentId}")
     public ResponseEntity<RoutineDto> createRoutine(
             @PathVariable Long dependentId,
@@ -53,6 +80,11 @@ public class RoutineController {
         return ResponseEntity.ok(routineService.createRoutine(dependentId, request));
     }
 
+    @Operation(
+            summary = "루틴 업데이트",
+            description = "피보호자 본인 또는 연결된 보호자만 피보호자의 식별자를 통해 접근 가능",
+            security = @SecurityRequirement(name = "Authorization")
+    )
     @PatchMapping("/{routineId}")
     public ResponseEntity<RoutineDto> updateRoutine(
             @PathVariable Long routineId,
@@ -61,6 +93,11 @@ public class RoutineController {
         return ResponseEntity.ok(response);
     }
 
+    @Operation(
+            summary = "루틴 삭제",
+            description = "Hard-delete, 데이터가 완전히 사라지며, 수행 기록은 보존됨",
+            security = @SecurityRequirement(name = "Authorization")
+    )
     @DeleteMapping("/{routineId}")
     public ResponseEntity<Void> deleteRoutine(
             @PathVariable Long routineId
@@ -69,6 +106,11 @@ public class RoutineController {
         return ResponseEntity.noContent().build();
     }
 
+    @Operation(
+            summary = "루틴 반복 데이터 업데이트",
+            description = "수정 사항을 원본에 덮어쓰기 방식으로 업데이트",
+            security = @SecurityRequirement(name = "Authorization")
+    )
     @PutMapping("/{routineId}/repeat")
     public ResponseEntity<List<RoutineRepeatDayDto>> updateRoutineRepeat(
             @PathVariable Long routineId,
@@ -77,6 +119,11 @@ public class RoutineController {
         return ResponseEntity.ok(routineService.updateRepeatDays(routineId, requests));
     }
 
+    @Operation(
+            summary = "루틴 메모 업데이트",
+            description = "요청하는 사용자의 역할에 따라 메모를 업데이트",
+            security = @SecurityRequirement(name = "Authorization")
+    )
     @PatchMapping("/{routineId}/memo")
     public ResponseEntity<RoutineDto> updateRoutineMemo(
             @PathVariable Long routineId,
@@ -85,6 +132,13 @@ public class RoutineController {
         return ResponseEntity.ok(routineService.updateRoutineMemo(routineId, content));
     }
 
+    @Operation(
+            summary = "루틴 수행 체크",
+            description = "당일 시작시간과 종료시간 사이에 체크 가능하며, 종료시간이 정의되지 않았을 경우 " +
+                    "당일 내로 체크 가능, 가능한 시간 외에 체크할 경우 실패로 처리 " +
+                    "(23:59분에 매일 요청하여 당일 루틴 수행 여부 일괄적으로 체크 가능)",
+            security = @SecurityRequirement(name = "Authorization")
+    )
     @PostMapping("/{routineId}/complete")
     public ResponseEntity<RoutineHistoryDto> completeRoutine(
             @PathVariable Long routineId
@@ -92,6 +146,11 @@ public class RoutineController {
         return ResponseEntity.ok(routineService.completeRoutine(routineId));
     }
 
+    @Operation(
+            summary = "루틴 수행 체크 철회",
+            description = "체크 해제할 경우 수행 기록이 삭제됨, 체크 가능 내에만 철회 가능",
+            security = @SecurityRequirement(name = "Authorization")
+    )
     @PatchMapping("/{historyId}/undo")
     public ResponseEntity<String> undoCompleteRoutine(
             @PathVariable Long historyId


### PR DESCRIPTION
# [Docs] Swagger API 명세 세부사항 작성 (태현) #98
- Swagger UI 세부 명세 작성 완료
- 빠른 개발을 위해 구조 개선하여 배포함, 테스트 코드 작성 및 버그 픽스는 차후 진행
- 음성 메세지, 사진 등 파일 처리 관련 API, 푸시 알림 관련 API 구현 필요
### feat: Swagger API 명세 세부사항 작성
- API 세부사항 작성
- 토큰 및 헤더 입력란 추가하여 테스트 가능
### fix: Connection 재연결 로직 수정
- ConnectionController의 재연결 reactivate -> 초대코드 수락 로직으로 옮김